### PR TITLE
Remove hard-coded CAS server path

### DIFF
--- a/CAS_bottle.py
+++ b/CAS_bottle.py
@@ -159,7 +159,7 @@ def _TestCASAuth(user) :
     
 def _CASLogout(cas_server,service_url):
     session=_getsession()
-    cas_logout=cas_server + "/cas/logout?service=" + service_url
+    cas_logout=cas_server + "/logout?service=" + service_url
     _pdebug("Cas Logout : ",cas_logout,"user=",session.get('user',None))
     session['user']=None
     session.save()
@@ -180,7 +180,7 @@ def _CASAuth(cas_server,service_url):
         ticket = bottle.request.params["ticket"]
         _pdebug("Ticket",ticket)
         #generate URL for ticket validation 
-        cas_validate = cas_server + "/cas/serviceValidate?ticket=" + ticket + "&service=" + service_url
+        cas_validate = cas_server + "/serviceValidate?ticket=" + ticket + "&service=" + service_url
         _pdebug("Opening : ",cas_validate)
         f_xml_assertion = urllib.request.urlopen(cas_validate)
         if not f_xml_assertion:
@@ -225,5 +225,5 @@ def _CASAuth(cas_server,service_url):
         else :
             session["redirect_url"]=bottle.request.url
         session.save()
-        bottle.redirect(cas_server + "/cas/login?service=" + service_url)
+        bottle.redirect(cas_server + "/login?service=" + service_url)
         

--- a/CAS_bottle.py
+++ b/CAS_bottle.py
@@ -29,7 +29,7 @@ session_opts = {
 app = SessionMiddleware(bottle.app(), session_opts)
 
 # Create the plugin
-auth=CAS_bottle.CASAuth(cas_server="https://your.cas.sever", #<= Your CAS server
+auth=CAS_bottle.CASAuth(cas_server="https://your.cas.sever/cas", #<= Your CAS server
                         service_url="http://localhost:8080/login")
 
 # Some callbacks require auth, some dont.
@@ -77,7 +77,7 @@ bottle.run(app, host='localhost', port=8080,debug= True, reloader=True)
 
 If you just want to use CAS authentification for all pages :
     
-auth=CAS_bottle.CASAuth(cas_server="https://your.cas.sever", #<= Your CAS server
+auth=CAS_bottle.CASAuth(cas_server="https://your.cas.sever/cas", #<= Your CAS server
                         service_url="http://localhost:8080/login")
 bottle.install(auth)
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ setup(
     author_email = 'snarkturne@gmail.com',
     requires = [
         'bottle (>=0.9)',
-        'beaker'
+        'beaker',
+        'six',
     ],
     classifiers = [
         'Environment :: Web Environment',

--- a/test_cas_bottle.py
+++ b/test_cas_bottle.py
@@ -12,7 +12,7 @@ session_opts = {
 app = SessionMiddleware(bottle.app(), session_opts)
 
 # Create the plugin
-auth=CAS_bottle.CASAuth(cas_server="https://your.cas.server", #<= Your CAS server
+auth=CAS_bottle.CASAuth(cas_server="https://your.cas.server/cas", #<= Your CAS server
                         service_url="http://localhost:8080/login")
 bottle.install(auth)
 # Some callbacks require auth, some dont.


### PR DESCRIPTION
We've got CAS deployed on a different URL and I had to modify the plugin to make it work.
